### PR TITLE
Updated new filepaths for the `CSS` and `JS` files after placing these files in the `assets` folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="assets/css/style.css" />
     <title>Work Day Scheduler</title>
   </head>
 
@@ -73,6 +73,6 @@
       crossorigin="anonymous"
     ></script>
 
-    <script src="script.js"></script>
+    <script src="assets/javascript/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I created a new folder called `assets` that contains two subdirectories one for CSS and the other for JavaScript files. As such, the links in the `index.html` had to be updated to reflect this new filepath / directory hierarchy.