### PR TITLE
Added code to `script.js` to print today's current date in the header section of `index.html`

### DIFF
--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -20,4 +20,6 @@ $(function () {
   // attribute of each time-block be used to do this?
   //
   // TODO: Add code to display the current date in the header of the page.
+  today = dayjs();
+  $("#currentDay").text(today.format("dddd, MMMM D")); // Did not see formatting options for adding the suffix st, rd, th, etc. from DayJS documentation
 });


### PR DESCRIPTION
No modifications were necessary for the `index.html` file because:

- Day.js was already linked in `index.html`
-  The `index.html` contained a section in the header for today's date with id "currentDay"

In `script.js`:

- Utilizing jQuery syntax, set the text of the "currentDay" paragraph to the returned value from calling Day.js's  `dayjs()` function 