### PR TITLE
Added logic to compare the time at initialization, or refresh, to apply styling to past, present, and future rows

### DIFF
--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -84,6 +84,19 @@ $(function () {
   // attribute of each time-block be used to conditionally add or remove the
   // past, present, and future classes? How can Day.js be used to get the
   // current hour in 24-hour time?
+var currentHour = dayjs().hour()
+
+for (i = 9; i < 18; i++){
+  if (i < currentHour) {
+    $("#hour-" + i).removeClass("present future").addClass("past");
+  } else if (i === currentHour) {
+    $("#hour-" + i).removeClass("past future").addClass("present");
+  } else {
+    $("#hour-" + i).removeClass("past present").addClass("future");
+  }
+}
+
+
   //
   // TODO: Add code to get any user input that was saved in localStorage and set
   // the values of the corresponding textarea elements. HINT: How can the id


### PR DESCRIPTION
The time at initialization, or refresh, is assigned to a variable `currentHour` which takes a value between 0-23.

To assign class and styling, we implement the following logic:

- If the numeric value in the hour/row id, which takes a value between 9 and 17 (inclusive), is less than `currentHour`, it is assigned the class "past" and is styled with a gray background. 
- If the numeric value in the hour/row id is equal to `currentHour`, it is assigned the class "present" and is tyled with a red background.
- If the numeric value in the hour/row id is greater than `currentHour`, it is assigned the class "future" and is styled with a green background.